### PR TITLE
Ignore lines from global/trade/guild/party chats

### DIFF
--- a/POE Trades Helper.ahk
+++ b/POE Trades Helper.ahk
@@ -151,7 +151,8 @@ Monitor_Game_Logs(mode="") {
 			lastMessage := fileObj.Read() ; Stores the last message into a var
 			Loop, parse, lastMessage, `n, `r ; This makes sure to not skip messages, when receiving multiple at once
 			{
-				if ( RegExMatch( A_LoopField, ".*\[.*\D+(.*)\].*@(?:From|De|От кого) (.*?): (.*)", subPat ) ) ; Whisper found --  (.*?) makes sure to stop at the first ":", fixing the "stash tab:" error
+				; New RegEx pattern matches the trading message, but only from whispers and local chat (for debugging), and specifically ignores global/trade/guild/party chats
+				if ( RegExMatch( A_LoopField, "^(?:[^ ]+ ){6}(\d+)\] [^#$&%].*@(?:From|De|От кого) (.*?): (.*)", subPat ) ) ; Whisper found --  (.*?) makes sure to stop at the first ":", fixing the "stash tab:" error
 				{
 					gamePID := subPat1, whispName := subPat2, whispMsg := subPat3
 					VALUE_Last_Whisper := whispName

--- a/POE Trades Helper.ahk
+++ b/POE Trades Helper.ahk
@@ -152,7 +152,7 @@ Monitor_Game_Logs(mode="") {
 			Loop, parse, lastMessage, `n, `r ; This makes sure to not skip messages, when receiving multiple at once
 			{
 				; New RegEx pattern matches the trading message, but only from whispers and local chat (for debugging), and specifically ignores global/trade/guild/party chats
-				if ( RegExMatch( A_LoopField, "^(?:[^ ]+ ){6}(\d+)\] [^#$&%].*@(?:From|De|От кого) (.*?): (.*)", subPat ) ) ; Whisper found --  (.*?) makes sure to stop at the first ":", fixing the "stash tab:" error
+				if ( RegExMatch( A_LoopField, "^(?:[^ ]+ ){6}(\d+)\] (?=[^#$&%]).*@(?:From|De|От кого) (.*?): (.*)", subPat ) ) ; Whisper found --  (.*?) makes sure to stop at the first ":", fixing the "stash tab:" error
 				{
 					gamePID := subPat1, whispName := subPat2, whispMsg := subPat3
 					VALUE_Last_Whisper := whispName


### PR DESCRIPTION
Prevents Monitor_Game_Logs() from matching trade messages sent via
global/trade/guild/party chats (Fixes #22). Trade messages on local chat
are still matched (so users can test using it).